### PR TITLE
Added build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, clone the repository.
 
 ```
 git clone https://github.com/bama4/simple-http-server.git
-cd simple_http_server/
+cd simple-http-server/
 ```
 
 Create a _build/_ directory to store the contents of the build process.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # simple-http-server
 A simple lightweight HTTP server in C
+
+## Building
+
+#### Requirements
+
+* CMake 3.10 or higher
+* GNU Make or another CMake compatible build tool 
+* C11 or higher compiler
+
+### Steps
+
+First, clone the repository.
+
+```
+git clone https://github.com/bama4/simple-http-server.git
+cd simple_http_server/
+```
+
+Create a _build/_ directory to store the contents of the build process.
+
+```
+mkdir build/
+cd build/
+```
+
+Then run CMake to generate the Makefile
+
+```
+cmake ../
+```
+
+Finally, run GNU make to compile the program.
+
+```
+make
+```
+
+The executable should be in the folder ``bin/`` and should be called simple_http_server

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A simple lightweight HTTP server in C
 * GNU Make or another CMake compatible build tool 
 * C11 or higher compiler
 
-### Steps
+#### Steps
 
 First, clone the repository.
 
 ```
 git clone https://github.com/bama4/simple-http-server.git
-cd simple_http_server/
+cd simple-http-server/
 ```
 
 Create a _build/_ directory to store the contents of the build process.


### PR DESCRIPTION
Adds basic build instructions to the README.md.  Explains cloning the repo, creating build directory, running CMake, and building it into an executable.  Not much else to it.

Closes #3 